### PR TITLE
implement std traits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           - rust: beta
             features: ""
           - rust: nightly
-            features: ""
+            features: "--all-features"
 
     steps:
       - uses: actions/checkout@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ edition = "2018"
 [dependencies]
 
 [dev-dependencies]
+
+[features]
+default = []
+nightly = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,10 @@
 //#![deny(missing_docs)] // TODO
 use core::{
     borrow::Borrow,
-    fmt, iter,
+    cmp::Ordering,
+    fmt,
+    hash::{Hash, Hasher},
+    iter,
     mem::{self, transmute, MaybeUninit},
     ops::DerefMut,
     ptr, slice,
@@ -644,6 +647,32 @@ impl fmt::Debug for Strs {
 impl Borrow<str> for Strs {
     fn borrow(&self) -> &str {
         self.as_str()
+    }
+}
+
+impl PartialEq for Strs {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for Strs {}
+
+impl PartialOrd for Strs {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.as_str().partial_cmp(other.as_str())
+    }
+}
+
+impl Ord for Strs {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl Hash for Strs {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,12 @@ use core::{
     ptr, slice,
     str::Utf8Error,
 };
-use std::{process::abort, rc::Rc, sync::Arc};
+use std::{
+    process::abort,
+    rc::Rc,
+    sync::Arc,
+    error::Error
+};
 
 /// Collection of strings.
 ///
@@ -704,6 +709,24 @@ impl Clone for Box<Strs> {
         let _ = Box::into_raw(boxed);
         unsafe {
             Box::from_raw(ptr)
+        }
+    }
+}
+
+impl fmt::Display for FromSliceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IndicesOrder => write!(f, "Indices are out of order"),
+            FromSliceError::NonUtf8 { offset, inner } => write!(f, "Data is not valid utf-8 at iffset {}: {}", offset, inner),
+        }
+    }
+}
+
+impl Error for FromSliceError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::IndicesOrder => None,
+            FromSliceError::NonUtf8 { offset: _, inner } => Some(inner),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -640,6 +640,13 @@ impl fmt::Debug for Strs {
     }
 }
 
+/// Note: this borrows the whole underling string, same as [`Strs::as_str`]
+impl Borrow<str> for Strs {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
 impl Strs {
     /// Creates `Strs` from raw parts.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 #![cfg_attr(feature = "nightly", feature(exact_size_is_empty))]
 //#![deny(missing_docs)] // TODO
 use core::{
-    convert::AsRef,
     cmp::Ordering,
+    convert::AsRef,
     fmt,
     hash::{Hash, Hasher},
     iter,
@@ -12,12 +12,7 @@ use core::{
     ptr, slice,
     str::Utf8Error,
 };
-use std::{
-    process::abort,
-    rc::Rc,
-    sync::Arc,
-    error::Error
-};
+use std::{error::Error, process::abort, rc::Rc, sync::Arc};
 
 /// Collection of strings.
 ///
@@ -707,9 +702,7 @@ impl Clone for Box<Strs> {
 
         let ptr = unsafe { Strs::from_slice_unchecked_mut(&mut *boxed) as *mut Strs };
         let _ = Box::into_raw(boxed);
-        unsafe {
-            Box::from_raw(ptr)
-        }
+        unsafe { Box::from_raw(ptr) }
     }
 }
 
@@ -717,7 +710,9 @@ impl fmt::Display for FromSliceError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::IndicesOrder => write!(f, "Indices are out of order"),
-            FromSliceError::NonUtf8 { offset, inner } => write!(f, "Data is not valid utf-8 at iffset {}: {}", offset, inner),
+            FromSliceError::NonUtf8 { offset, inner } => {
+                write!(f, "Data is not valid utf-8 at iffset {}: {}", offset, inner)
+            }
         }
     }
 }
@@ -802,9 +797,7 @@ impl Strs {
 
     fn as_raw(&self) -> &[usize] {
         let length = 1 + ceiling_div(self.buf.len(), mem::size_of::<usize>());
-        unsafe {
-            slice::from_raw_parts(self as *const Strs as *const usize, length)
-        }
+        unsafe { slice::from_raw_parts(self as *const Strs as *const usize, length) }
     }
 }
 
@@ -906,8 +899,8 @@ pub(crate) fn malicious_as_ref(_n: u8) -> ! {
 mod tests {
     use crate::Strs;
     use core::mem::{self, MaybeUninit};
-    use std::convert::AsRef;
     use std::cell::Cell;
+    use std::convert::AsRef;
 
     #[test]
     fn from_vec() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -749,6 +749,7 @@ impl Strs {
 /// Iterator over strings in [`Strs`]
 ///
 /// See [`Strs::iter`]
+#[derive(Debug)]
 pub struct Iter<'a> {
     strs: &'a Strs,
     // TODO: probably it would be better to implement this with pointers to idx buffer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -679,21 +679,7 @@ impl PartialOrd for Strs {
 
 impl Ord for Strs {
     fn cmp(&self, other: &Self) -> Ordering {
-        let mut left = self.iter();
-        let right = other.iter();
-
-        for (l, r) in left.by_ref().zip(right) {
-            // I wish we had or-patterns
-            if let ret @ Ordering::Less | ret @ Ordering::Greater = l.cmp(r) {
-                 return ret;
-            }
-        }
-
-        // The head of both iterators are equal, then bigger is the one that is bigger
-        match left.next() {
-            Some(_) => Ordering::Greater,
-            None => Ordering::Less,
-        }
+        self.iter().cmp(other.iter())
     }
 }
 


### PR DESCRIPTION
This PR:
- entroduces `Iter<'a>` and `impl IntoIterator for &'a Strs`
- Makes `Debug` output the actual strings, not the raw bytes
- adds `impl _ for Strs`
  + `AsRef<str>`
  + `PartialEq`, `Eq`
  + `PartialOrd`, `Ord`
  + `Hash`
- adds `impl Clone for Box<Strs>`
- implement `fmt::Display` and `Error` for `FromSliceError`
- replaces `Borrow` => `AsRef` everywhere to accept more types
- adds `nightly` crate feature